### PR TITLE
suppress warnings when ignoring https

### DIFF
--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -115,6 +115,9 @@ def main():
     if args.ca_bundle:
         if args.ca_bundle.lower() == "false":
             args.ca_bundle = False
+            # according to: https://stackoverflow.com/a/28002687/131120
+            import requests.packages.urllib3 as urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
         else:
             if not os.path.exists(args.ca_bundle):
                 logger.error("INFRABOX_CA_BUNDLE: %s not found" % args.ca_bundle)


### PR DESCRIPTION
Since it's sending 3 requests per second to the infrabox server, these warnings will make up the most part of a `infrabox push --show-console` output. This change removes the spam and lets the user bath in the glory of his insecure behaviour.