### PR TITLE
fix(pull): Fix pull container input with nested directories

### DIFF
--- a/infraboxcli/pull.py
+++ b/infraboxcli/pull.py
@@ -64,7 +64,7 @@ def pull(args):
     for d in manifest['dependencies']:
         p = os.path.join(inputs_path, d['name'])
         logger.info('Downloading output of %s to %s' % (d['name'], p))
-        os.makedirs(p)
+        os.makedirs(p, exist_ok=True)
         package_path = os.path.join(download_path, '%s.%s' % (d['id'], d['output']['format']))
         download_file(d['output']['url'], package_path, args)
 


### PR DESCRIPTION
Error was:
OSError: [Errno 17] File exists: '/tmp/infrabox/b5765a38-46c0-4455-94e1-087d653f074d/inputs/mirror-images'