### PR TITLE
fix: correctly get child jobs

### DIFF
--- a/infraboxcli/workflow.py
+++ b/infraboxcli/workflow.py
@@ -45,7 +45,10 @@ class WorkflowCache(object):
 
                 if children:
                     for p in j.get('depends_on', []):
-                        jobs += self.get_jobs(p['name'], children)
+                        if 'name' in p:
+                            jobs += self.get_jobs(p['name'], children)
+                        if 'job' in p:
+                            jobs += self.get_jobs(p['job'], children)
 
         if not jobs:
             logger.error("job %s not found in infrabox.json" % job_name)


### PR DESCRIPTION
Before it was checking for a key called `name` although the dependent jobs are under the key `job`:
```
            "depends_on": [
                {
                    "on": [
                        "finished"
                    ],
                    "job": "generator/vsystem-images-build_stage"
                }
            ],
```
Leaving the old check for the key `name` though.