### PR TITLE
show Job name when checking infrabox.json format failed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 
 # exuberant ctags
 tags
+
+.vscode
+

--- a/infraboxcli/job_list.py
+++ b/infraboxcli/job_list.py
@@ -23,7 +23,10 @@ def load_infrabox_file(path):
             data = json.load(f)
         except ValueError:
             f.seek(0)
-            data = yaml.load(f)
+            if (sys.version_info.major == 2) or (yaml.__version__ < "5.1"):
+                data = yaml.load(f)
+            else:
+                data = yaml.load(f, Loader=yaml.FullLoader)
         validate_json(data)
         return data
 

--- a/infraboxcli/validate.py
+++ b/infraboxcli/validate.py
@@ -19,7 +19,7 @@ def validate_infrabox_file(args):
             data = json.load(f)
         except ValueError:
             f.seek(0)
-            data = yaml.load(f)
+            data = yaml.load(f, Loader=yaml.FullLoader)
         validate_json(data)
 
 def validate(args):

--- a/infraboxcli/validate.py
+++ b/infraboxcli/validate.py
@@ -19,7 +19,7 @@ def validate_infrabox_file(args):
             data = json.load(f)
         except ValueError:
             f.seek(0)
-            if sys.version_info.major == 2:
+            if (sys.version_info.major == 2) or (yaml.__version__ < "5.1"):
                 data = yaml.load(f)
             else:
                 data = yaml.load(f, Loader=yaml.FullLoader)

--- a/infraboxcli/validate.py
+++ b/infraboxcli/validate.py
@@ -19,7 +19,10 @@ def validate_infrabox_file(args):
             data = json.load(f)
         except ValueError:
             f.seek(0)
-            data = yaml.load(f, Loader=yaml.FullLoader)
+            if sys.version_info.major == 2:
+                data = yaml.load(f)
+            else:
+                data = yaml.load(f, Loader=yaml.FullLoader)
         validate_json(data)
 
 def validate(args):

--- a/infraboxcli/workflow.py
+++ b/infraboxcli/workflow.py
@@ -111,18 +111,36 @@ class WorkflowCache(object):
                     label=cluster['name'].split('/')[-1],
                     indent=indent))
             elif len(cluster) == 1:
-                for inner_name, inner_cluster in cluster.iteritems():
-                    print_cluster(inner_name, inner_cluster, indent)
+                if (sys.version_info.major == 2):
+                    for inner_name, inner_cluster in cluster.iteritems():
+                        print_cluster(inner_name, inner_cluster, indent)
+                elif (sys.version_info.major == 3):
+                    for inner_name, inner_cluster in cluster.items():
+                        print_cluster(inner_name, inner_cluster, indent)
+                else:
+                    raise Exception('Unsupport python version')
             else:
                 print('{indent}subgraph "cluster_{name}" {{'.format(name=name, indent=indent))
 
-                for inner_name, inner_cluster in cluster.iteritems():
-                    print_cluster(inner_name, inner_cluster, indent + '  ')
+                if (sys.version_info.major == 2):
+                    for inner_name, inner_cluster in cluster.iteritems():
+                        print_cluster(inner_name, inner_cluster, indent + '  ')
+                elif (sys.version_info.major == 3):
+                    for inner_name, inner_cluster in cluster.items():
+                        print_cluster(inner_name, inner_cluster, indent + '  ')
+                else:
+                    raise Exception('Unsupport python version')
 
                 print('{indent}}}'.format(indent=indent))
 
-        for name, cluster in index.iteritems():
-            print_cluster(name, cluster)
+        if (sys.version_info.major == 2):
+            for name, cluster in index.iteritems():
+                print_cluster(name, cluster)
+        elif (sys.version_info.major == 3):
+            for name, cluster in index.items():
+                print_cluster(name, cluster)
+        else:
+            raise Exception('Unsupport python version')
 
         for j in self.jobs:
             name = j['name']

--- a/pyinfrabox/utils.py
+++ b/pyinfrabox/utils.py
@@ -30,7 +30,7 @@ def check_allowed_properties(d, path, allowed):
     for key in d:
         if key not in allowed:
             if 'name' in d.keys():
-                raise ValidationError(path + '(' + d['name'] + ')', "invalid property '%s'" % key)
+                raise ValidationError('%s(%s)' % (path, d['name']), "invalid property '%s'" % key)
             else:
                 raise ValidationError(path, "invalid property '%s'" % key)
 
@@ -42,7 +42,7 @@ def check_required_properties(d, path, required):
     for key in required:
         if key not in d:
             if 'name' in d.keys():
-                raise ValidationError(path + '(' + d['name'] + ')', "property '%s' is required" % key)
+                raise ValidationError('%s(%s)' % (path, d['name']), "property '%s' is required" % key)
             else:
                 raise ValidationError(path, "property '%s' is required" % key)
 

--- a/pyinfrabox/utils.py
+++ b/pyinfrabox/utils.py
@@ -29,8 +29,10 @@ def check_allowed_properties(d, path, allowed):
 
     for key in d:
         if key not in allowed:
-            raise ValidationError(path + '(' + d['name'] + ')',
-                                  "invalid property '%s'" % key)
+            if 'name' in d.keys():
+                raise ValidationError(path + '(' + d['name'] + ')', "invalid property '%s'" % key)
+            else:
+                raise ValidationError(path, "invalid property '%s'" % key)
 
 
 def check_required_properties(d, path, required):
@@ -39,9 +41,10 @@ def check_required_properties(d, path, required):
 
     for key in required:
         if key not in d:
-            raise ValidationError(path + '(' + d['name'] + ')',
-                                  "property '%s' is required" % key)
-
+            if 'name' in d.keys():
+                raise ValidationError(path + '(' + d['name'] + ')', "property '%s' is required" % key)
+            else:
+                raise ValidationError(path, "property '%s' is required" % key)
 
 def check_string_array(e, path):
     if not isinstance(e, list):

--- a/pyinfrabox/utils.py
+++ b/pyinfrabox/utils.py
@@ -22,13 +22,16 @@ def check_text(t, path, allowEmpty=False):
     if not allowEmpty and not t:
         raise ValidationError(path, "empty string not allowed")
 
+
 def check_allowed_properties(d, path, allowed):
     if not isinstance(d, dict):
         raise ValidationError(path, "must be an object")
 
     for key in d:
         if key not in allowed:
-            raise ValidationError(path, "invalid property '%s'" % key)
+            raise ValidationError(path + '(' + d['name'] + ')',
+                                  "invalid property '%s'" % key)
+
 
 def check_required_properties(d, path, required):
     if not isinstance(d, dict):
@@ -36,7 +39,9 @@ def check_required_properties(d, path, required):
 
     for key in required:
         if key not in d:
-            raise ValidationError(path, "property '%s' is required" % key)
+            raise ValidationError(path + '(' + d['name'] + ')',
+                                  "property '%s' is required" % key)
+
 
 def check_string_array(e, path):
     if not isinstance(e, list):
@@ -50,25 +55,32 @@ def check_string_array(e, path):
         path = "%s[%s]" % (path, i)
         check_text(elem, path)
 
+
 def check_boolean(d, path):
     if not isinstance(d, bool):
         raise ValidationError(path, "must be a boolean")
+
 
 def check_number(d, path):
     if not isinstance(d, int):
         raise ValidationError(path, "must be a integer")
 
+
 def check_int_or_float(d, path):
     if not isinstance(d, float) and not isinstance(d, int):
         raise ValidationError(path, "must be a float")
 
+
 def check_color(d, path):
-    if d not in ("red", "green", "blue", "yellow", "orange", "white", "black", "grey"):
+    if d not in ("red", "green", "blue", "yellow", "orange", "white", "black",
+                 "grey"):
         raise ValidationError(path, "not a valid value")
+
 
 def get_remote_url(url):
     parsed_url = urlparse(url)
     return parsed_url.scheme + '://' + parsed_url.netloc
+
 
 def validate_url(url):
     try:
@@ -76,6 +88,7 @@ def validate_url(url):
         return result.scheme and result.netloc
     except:
         return False
+
 
 def validate_uuid(uuid_string):
     try:


### PR DESCRIPTION
While using the "infrabox -f infrabox.json validate" to check the infrabox project json file format, when there is invalid property name found, this tool does not show which Job contains the property name.
The fixing here will show the job name which has the invalid property name.
