### PR TITLE
fix the issue of fail to install infraboxcli on python2

### DIFF
--- a/infraboxcli/__init__.py
+++ b/infraboxcli/__init__.py
@@ -17,7 +17,7 @@ from infraboxcli.dashboard import remotes
 from infraboxcli.dashboard import local_config
 from infraboxcli.install import install_infrabox
 
-version = '0.8.7'
+version = '0.8.8'
 
 def main():
     username = 'unknown'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='infraboxcli',
-      version='0.8.7',
+      version='0.8.8',
       url='https://github.com/infrabox/cli',
       description='Command Line Interface for InfraBox',
       long_description=readme(),
@@ -22,11 +22,10 @@ setup(name='infraboxcli',
                 'pyinfrabox.testresult'],
       install_requires=[
           'future',
-          'jsonschema',
+          'jsonschema==2.6.0',
           'requests',
           'colorama==0.3.9',
           'socketIO_client',
-          'pyyaml',
           'PyJWT',
           'cryptography',
           'inquirer',


### PR DESCRIPTION
Because of module "jsonschema" start from version 3.0.0 does not support python2, so here need to set the version 2.6.0 in setup.py for python2.
