### PR TITLE
Create .infrabox/work/jobs/<job_name>/infrabox/upload/archive as non-root

### DIFF
--- a/infraboxcli/run.py
+++ b/infraboxcli/run.py
@@ -93,6 +93,8 @@ def create_infrabox_directories(args, job, service=None, services=None, compose_
     # docker will create them as root!
     makedirs_if_not_exists(infrabox_cache)
     makedirs_if_not_exists(infrabox_local_cache)
+    makedirs_if_not_exists(infrabox_upload)
+    makedirs_if_not_exists(infrabox_archive)
 
     logger.info('Recreating directories')
 


### PR DESCRIPTION
If an infrabox job is run for the first time, the directory
.infrabox/work/jobs/<job_name>/infrabox/upload/archive
is created as root. This causes an error if the job is running as non-root user.